### PR TITLE
Run script: Add script descriptions to quick pick items

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -2,7 +2,7 @@ import * as Path from 'path';
 import * as Fs from 'fs';
 
 import { workspace as Workspace,
-         window as Window } from 'vscode';
+         window as Window, QuickPickItem } from 'vscode';
 
 import * as Messages from './messages';
 import { runCommand } from './run-command';
@@ -14,9 +14,14 @@ export default function () {
         return;
     }
     
-    Window.showQuickPick(Object.keys(scripts)).then((value) => {
+    const items: QuickPickItem[] = Object.keys(scripts).map((key) => {
         
-        runCommand(['run', value]);
+        return { label: key, description: scripts[key] };
+    });
+    
+    Window.showQuickPick(items).then((value) => {
+        
+        runCommand(['run', value.label]);
     });
 };
 


### PR DESCRIPTION
This is a feature of the other [npm script runner extension](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script) that I thought was pretty neat. It shows what's actually going to be run by the script names.

<img width="320" alt="scripts" src="https://cloud.githubusercontent.com/assets/6125444/13945671/6ff71ad8-f00f-11e5-903d-9d5b327161e1.png">

It was an easy change so I thought I'd go ahead and submit a PR. You can take it if you think it's a good idea, or leave it :)
