### PR TITLE
Hack to "run script" command name, to make it appear above "run last script" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       },
       {
         "command": "npm-script.runScript",
-        "title": "Run npm script",
+        "title": "Run  npm script",
         "category": "npm"
       },
       {


### PR DESCRIPTION
cc @Gigitsu 

<img width="334" alt="run-before" src="https://cloud.githubusercontent.com/assets/6125444/15628594/002634f2-2505-11e6-857d-506522da85c2.png">

The problem with the addition of the latest `Run last npm script` command is that when you open the command palette and type "npm run" you now get this command, instead of the standard `npm: Run npm script` command, which is what you got before and is the more sensible default I think.

My initial though was maybe the new command could be renamed `Re-run last npm script`, but then that command won't show up at all when typing "npm run", reducing discoverability.

Then I found it could be fixed in a hacky way by adding an extra space into the command title: 

```
Run  npm script
```

Which nicely puts it above the "run last script" command, but doesn't change the appearance.

<img width="334" alt="run-after" src="https://cloud.githubusercontent.com/assets/6125444/15628652/b9af0be6-2506-11e6-8feb-cb5983ede280.png">

The only downside as far as I can see is that it's a hack, so I guess there's a small chance it might not work in future vscode versions. But I couldn't find any other way in the vscode docs of manually adjusting the order in which commands show up.

@fknop BTW I have another PR coming shortly.
